### PR TITLE
fix compile errors due to missing standard library definitions

### DIFF
--- a/include/voxelio/sstreamwrap.hpp
+++ b/include/voxelio/sstreamwrap.hpp
@@ -1,6 +1,7 @@
 #ifndef VXIO_SSTREAMWRAP_HPP
 #define VXIO_SSTREAMWRAP_HPP
 
+#include <ios>
 #include <iosfwd>
 #include <string>
 

--- a/include/voxelio/stringify.hpp
+++ b/include/voxelio/stringify.hpp
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <iosfwd>
 #include <string>
+#include <ios>
 
 namespace voxelio {
 

--- a/src/3rd_party/miniz_cpp.cpp
+++ b/src/3rd_party/miniz_cpp.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <fstream>
 #include <cstring>
+#include <limits>
 
 namespace miniz_cpp {
 

--- a/src/assert.cpp
+++ b/src/assert.cpp
@@ -6,6 +6,7 @@
 
 #include <exception>
 #include <vector>
+#include <exception>
 
 namespace voxelio {
 


### PR DESCRIPTION
The source code did not compile on some platforms due to missing include directives for standard library features used in the corresponding files. These were added.