### PR TITLE
fix type mismatch on aarch64-darwin

### DIFF
--- a/src/format/qb.cpp
+++ b/src/format/qb.cpp
@@ -233,7 +233,7 @@ ReadResult Reader::readUncompressed(Voxel64 buffer[], usize bufferLength) noexce
     VXIO_DEBUG_ASSERT_LE(index, matVolume);
     VXIO_DEBUG_ASSERT_GT(bufferLength, 0u);
 
-    const auto voxelsLeftInMatrixCount = matVolume - index;
+    const usize voxelsLeftInMatrixCount = matVolume - index;
     if (voxelsLeftInMatrixCount == 0) return ReadResult::nextObject();
 
     const auto tmpBufferSize = std::min(bufferLength, voxelsLeftInMatrixCount);


### PR DESCRIPTION
The `auto` declaration leads to a type mismatch on aarch64-darwin: https://logs.ofborg.org/?key=nixos/nixpkgs.254299&attempt_id=70d98e7c-455f-48e0-a984-14a402f9d64e

This fix should also generally improve portability.